### PR TITLE
Fixed File Checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ local.properties
 .project
 .classpath
 
+# IntelliJ
+/.idea/
+
 # External tool builders
 .externalToolBuilders/
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sat Mar 21 14:32:59 CDT 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,0 @@
-#Sat Mar 21 14:32:59 CDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/clubobsidian/wrappy/Configuration.java
+++ b/src/main/java/com/clubobsidian/wrappy/Configuration.java
@@ -163,7 +163,7 @@ public class Configuration extends ConfigurationSection {
 			reader.close();
 			writer.close();
 			//FileUtils.copyURLToFile(url, tempFile, connectionTimeout, readTimeout);
-			if(tempFile.length() > 0 && tempFile.length() != backupFile.length())
+			if(tempFile.length() > 0 && !FileUtils.contentEquals(tempFile, backupFile))
 			{
 				if(backupFile.exists())
 				{


### PR DESCRIPTION
Fixed checking equality of temp file and backup file. If the length was the same but content was different, the files would show as equal. Now, Apache Commons FileUtils is used to check if the two files are equal, and will return false if the files are not the same (bit by bit comparison).